### PR TITLE
fix(answers object): now passing the checkout property as part of the…

### DIFF
--- a/.changeset/big-rats-kick.md
+++ b/.changeset/big-rats-kick.md
@@ -1,0 +1,5 @@
+---
+"@branchlint/cli": minor
+---
+
+Now passing the checkout property with the answers object to the callbacks such as command.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,14 +22,18 @@ void (async () => {
 		}
 
 		// Build the CLI steps from the config
-		const { checkout, ...answers } = await inquirer.prompt([
+		const answers = await inquirer.prompt([
 			config.prefix,
 			config.middle,
 			config.suffix,
 			config.postCommand,
 		]);
 		// Convert input from the CLI to kebab-case and separate prefix, middle, and suffix by the passed separator.
-		const branchName = Object.values(answers as Record<PropertyKey, string>)
+		// Don't transform checkout.
+		const { checkout, ...toTransform } = answers;
+		const branchName = Object.values(
+			toTransform as Record<PropertyKey, string>,
+		)
 			?.map(kebabCase)
 			?.join(config.separator);
 		const command = config.command(branchName, answers);


### PR DESCRIPTION
… answers object

this allows to create a command override and be able to use the checkoujt property.